### PR TITLE
fix: golangci-lint go@1.19 workaround

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,36 +7,28 @@ on:
 permissions:
   contents: read
 
-jobs:
-  golangci:
-    name: lint
+jjobs:
+  # ...
+  lint-go:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.19
-      - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true then the all caching functionality will be complete disabled,
-          #           takes precedence over all other caching options.
-          # skip-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
+          # go-version: 1.19
+          go-version-file: go.mod
+          # The builtin cache feature ensures that installing golangci-lint
+          # is consistently fast.
+          cache: true
+          cache-dependency-path: go.sum
+      - name: Install golangci-lint
+        # Install golangci-lint from source instead of using
+        # golangci-lint-action to ensure the golangci-lint binary is built with
+        # the same Go version we're targeting.
+        # Avoids incompatibility issues such as:
+        # - https://github.com/golangci/golangci-lint/issues/2922
+        # - https://github.com/golangci/golangci-lint/issues/2673
+        # - https://github.com/golangci/golangci-lint-action/issues/442
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.3
+      - name: Run golangci-lint
+        run: golangci-lint run --version --verbose --out-format=github-actions


### PR DESCRIPTION
Building linter in place